### PR TITLE
Fix css display error

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,8 @@
 export default {
   plugins: {
     '@tailwindcss/postcss': {},
+    // Ensure DaisyUI runs so theme variables like --b1/--bc are generated
+    'daisyui': {},
     autoprefixer: {},
   },
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@plugin "daisyui";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -14,6 +15,8 @@ html, body, #root {
 }
 
 body {
+  /* Fallback to pastel yellow if DaisyUI variables are not present */
+  background-color: #FFF8DC;
   background-color: hsl(var(--b1));
   color: hsl(var(--bc));
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Add DaisyUI PostCSS plugin and declare it in global CSS to fix missing theme variables for pastel background.

The `body` element's `data-theme="pastel"` relies on DaisyUI to define CSS variables like `--b1`. Previously, the DaisyUI plugin was not active in the PostCSS pipeline, preventing these variables from being generated and causing the pastel background to not render. This change ensures the theme variables are correctly emitted and includes a fallback background color for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb10539a-2a1f-4316-b8ab-daa17364ff7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb10539a-2a1f-4316-b8ab-daa17364ff7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

